### PR TITLE
more compatible with sklearn + weight_function can be custom function

### DIFF
--- a/SW/SW.py
+++ b/SW/SW.py
@@ -10,24 +10,52 @@ SW transformation
 
 import numpy as np
 
-EPS= 1e-20
+def _check_adjacency(X):
+    return (X.data!=1).sum()!=0
+
+def _top_sum(X):
+    return np.squeeze(np.asarray(X.sum(axis=0))) + EPS
+
+def _tanh(X):
+    X_sum_0 = _top_sum(X)
+    return np.tanh(1.0/X_sum_0)
+
+def _simple(X):
+    return np.ones((X.shape[1],))
+
+def _inverse(X):
+    X_sum_0 = _top_sum(X)
+    return 1.0/X_sum_0
+
+WEIGHT_FUNCTIONS = {
+    "tanh": _tanh,
+    "simple": _simple,
+    "inverse": _inverse
+}
+
+EPS = 1e-20
+
 class SW_transformation:
-    def __init__(self, weight_function='tanh', weights=None):
+    def __init__(self, weight_function='tanh'):
         """
         Parameters
         ----------
-        weight_function : 'tanh','inverse','simple' or 'own' (default='tanh'). 
-        For 'own', the top node weights should be provided in weights
-           
-        weights : array-like, shape (1, n_top_nodes). Vector containing the top
-        node weights, where n_top_nodes is the number of top nodes. When 
-        weight_function is set at 'own', the top node weights should be 
-        provided here. 
-        """
-    
+        weight_function : 'tanh','inverse' or 'simple' (default='tanh'). 
+        If you want to add your own custom weights, you can provide a function,
+        that takes as input argument the input matrix X and outputs the top node weights with
+        dimensions (n_top_nodes=X.shape[1],)   
+        """ 
+        
         self.weight_function = weight_function
-        self.weights = weights
-            
+           
+    def get_params(self, deep=True):
+        return {"weight_function": self.weight_function}
+
+    def set_params(self, **parameters):
+        for parameter, value in parameters.items():
+            setattr(self, parameter, value)
+        return self
+
     def fit(self, X, y):
         """
         Fit the model according to the given training data.
@@ -39,27 +67,28 @@ class SW_transformation:
         y : array-like, shape (n_bottom nodes, 1)
             Target vector relative to X.
         """
-        if self.weight_function == 'tanh':
-            top_node_weights = np.tanh(1/(np.sum(X, axis=0)+EPS))
-        elif self.weight_function == 'simple':
-            top_node_weights = np.ones((1,X.shape[1]))
-        elif self.weight_function == 'inverse':
-            top_node_weights = 1/(np.sum(X,axis=0)+EPS)
-        elif self.weight_function == 'own':
-            top_node_weights = self.weights
-          
+        if _check_adjacency(X):
+          raise ValueError("Input matrix X should only contain ones or zeros")
+
+        if callable(self.weight_function):
+          top_node_weights = self.weight_function(X)
         else:
-            raise Exception('please enter a valid weight function: "tanh", "simple", "inverse" or "own" ')
-            
-        nsk = X.T*y
-        try:
-            self.top_node_scores= np.array(nsk.T)*np.array(top_node_weights)
-        except:
-            raise Exception('please enter top node weights with correct dimensions (1, n_top_nodes)')
-        self.Z=np.array(top_node_weights)*np.array(np.sum(X,axis=0)+EPS)
-        return self
-       
+          try:
+            top_node_weights = WEIGHT_FUNCTIONS[self.weight_function](X)
+          except KeyError:
+            raise ValueError('please enter a valid weight function: "tanh", "simple" or "inverse"')
         
+        if len(top_node_weights) != X.shape[1]:
+          raise ValueError('please make sure your weight_function outputs top node weights with the correct dimensions (n_top_nodes=X.shape[1],)')
+           
+        nsk = np.squeeze(X.T*y)
+        self.coef_= np.reshape(nsk*top_node_weights,(1,X.shape[1]))
+
+        X_sum_0 = _top_sum(X)
+        self.Z_=np.reshape(top_node_weights*X_sum_0,(1,X.shape[1]))
+        
+        return self
+      
     def predict_proba(self, X):
         """
         Probability estimates.
@@ -69,11 +98,14 @@ class SW_transformation:
         X : sparse matrix, shape = [n_bottom_nodes, n_top_nodes]
         Returns
         -------
-        pred_scores : array-like, shape = [n_bottom_nodes,1]
-            Returns the probability of the bottom node for the positive class.
+        pred_scores : array-like, shape = [n_bottom_nodes,2]
+            Returns the probability of the bottom node for the negative and positive class.
         """
-
-        top_node_sum= X*self.top_node_scores.T
-        Z_sum=X*self.Z.T
-        pred_scores= np.divide(top_node_sum, Z_sum+EPS)
-        return pred_scores
+        if _check_adjacency(X):
+          raise ValueError("Input matrix X should only contain ones or zeros")
+        
+        top_node_sum= X*self.coef_.T
+        Z_sum=X*self.Z_.T
+        scores = np.divide(top_node_sum, Z_sum+EPS)
+        scores = np.hstack((1.0-scores,scores))
+        return scores


### PR DESCRIPTION
Changes made:

- added basic checks to ensure the input matrix contains only zeros and ones
- reorganized the weight_function selection code (using a dict now instead of if-else)
- weight_function can now be a string or a custom function (replacing the second weights argument)
- predict_proba outputs two column matrix, containing probabilities for the negative (first column) and postive class (second column) to work with sklearn grid_search
- added get_params and set_params to work with sklearn grid_search but to avoid dependency on the sklearn library

I used this for testing:

```
from sklearn.model_selection import GridSearchCV

X = ...
y = ...

custom = lambda X: np.ones((X.shape[1],))

sw = SW_transformation()
parameters = {'weight_function':('tanh','inverse','simple',custom)}
clf = GridSearchCV(sw, parameters, cv=5, scoring = 'roc_auc', verbose=3)
clf.fit(X,y)
```

Please test and verify as well to ensure it does not break anything

This grid_search 'framework' can then also be used selecting the parameters for this beta-weight function? 